### PR TITLE
Prevent background register

### DIFF
--- a/android/src/main/java/com/adivery/plugin/AdiveryPlugin.java
+++ b/android/src/main/java/com/adivery/plugin/AdiveryPlugin.java
@@ -1,11 +1,13 @@
 package com.adivery.plugin;
 
-
 import android.app.Activity;
+import android.app.ActivityManager;
+import android.content.Context;
+
+import androidx.annotation.NonNull;
 
 import com.adivery.sdk.Adivery;
 import com.adivery.sdk.AdiveryListener;
-import com.adivery.sdk.networks.adivery.AdiveryNativeAd;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -21,7 +23,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /**
  * AdiveryPlugin
@@ -34,19 +35,19 @@ public class AdiveryPlugin implements FlutterPlugin, MethodCallHandler, Activity
   private final List<BaseAd> ads = new ArrayList<>();
   private boolean isInitialized = false;
 
-  private final AdiveryListener listener = new AdiveryListener(){
+  private final AdiveryListener listener = new AdiveryListener() {
     @Override
-    public void onRewardedAdShown(String placementId) {
+    public void onRewardedAdShown(@NonNull String placementId) {
       channel.invokeMethod("onRewardedAdShown", placementId);
     }
 
     @Override
-    public void onRewardedAdLoaded(String placementId) {
+    public void onRewardedAdLoaded(@NonNull String placementId) {
       channel.invokeMethod("onRewardedAdLoaded", placementId);
     }
 
     @Override
-    public void onRewardedAdClosed(String placementId, boolean isRewarded) {
+    public void onRewardedAdClosed(@NonNull String placementId, boolean isRewarded) {
       Map<String, Object> arguments = new HashMap<>();
       arguments.put("placement_id", placementId);
       arguments.put("is_rewarded", isRewarded);
@@ -54,32 +55,32 @@ public class AdiveryPlugin implements FlutterPlugin, MethodCallHandler, Activity
     }
 
     @Override
-    public void onRewardedAdClicked(String placementId) {
+    public void onRewardedAdClicked(@NonNull String placementId) {
       channel.invokeMethod("onRewardedAdClicked", placementId);
     }
 
     @Override
-    public void onInterstitialAdShown(String placementId) {
+    public void onInterstitialAdShown(@NonNull String placementId) {
       channel.invokeMethod("onInterstitialAdShown", placementId);
     }
 
     @Override
-    public void onInterstitialAdLoaded(String placementId) {
+    public void onInterstitialAdLoaded(@NonNull String placementId) {
       channel.invokeMethod("onInterstitialAdLoaded", placementId);
     }
 
     @Override
-    public void onInterstitialAdClosed(String placementId) {
+    public void onInterstitialAdClosed(@NonNull String placementId) {
       channel.invokeMethod("onInterstitialAdClosed", placementId);
     }
 
     @Override
-    public void onInterstitialAdClicked(String placementId) {
+    public void onInterstitialAdClicked(@NonNull String placementId) {
       channel.invokeMethod("onInterstitialAdClicked", placementId);
     }
 
     @Override
-    public void log(String placementId, String reason) {
+    public void log(@NonNull String placementId, @NonNull String reason) {
       Map<String, String> arguments = new HashMap<>();
       arguments.put("placement_id", placementId);
       arguments.put("reason", reason);
@@ -87,12 +88,28 @@ public class AdiveryPlugin implements FlutterPlugin, MethodCallHandler, Activity
     }
   };
 
+  private static boolean isAppInBackground(Context context) {
+    ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+    List<ActivityManager.RunningAppProcessInfo> runningProcesses = activityManager.getRunningAppProcesses();
+    for (ActivityManager.RunningAppProcessInfo processInfo : runningProcesses) {
+      if (processInfo.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND) {
+        for (String activeProcess : processInfo.pkgList) {
+          if (activeProcess.equals(context.getPackageName())) {
+            return false;
+          }
+        }
+      }
+    }
+
+    return true;
+  }
 
   @Override
-  public void onAttachedToEngine(FlutterPluginBinding flutterPluginBinding) {
-    if (messenger != null){
+  public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
+    if (messenger != null || isAppInBackground(flutterPluginBinding.getApplicationContext())) {
       return;
     }
+
     channel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(),
         "adivery_plugin");
     channel.setMethodCallHandler(this);
@@ -104,29 +121,11 @@ public class AdiveryPlugin implements FlutterPlugin, MethodCallHandler, Activity
             new AdiveryAdViewFactory(flutterPluginBinding.getBinaryMessenger()));
   }
 
-
-  // handling flutter api v1
-  public static void registerWith(Registrar registrar) {
-    if (messenger != null){
-      return;
-    }
-    final MethodChannel channel = new MethodChannel(registrar.messenger(), "adivery_plugin");
-    channel.setMethodCallHandler(new AdiveryPlugin());
-
-    activity = registrar.activity();
-    messenger = registrar.messenger();
-
-    // factory for banner ad.
-    registrar.platformViewRegistry()
-        .registerViewFactory("adivery/bannerAd",
-            new AdiveryAdViewFactory(registrar.messenger()));
-  }
-
   @Override
-  public void onMethodCall(MethodCall call, Result result) {
+  public void onMethodCall(MethodCall call, @NonNull Result result) {
     switch (call.method) {
       case "initialize":
-        Adivery.configure(activity.getApplication(), (String) call.argument("appId"));
+        Adivery.configure(activity.getApplication(), call.argument("appId"));
         Adivery.addGlobalListener(listener);
         isInitialized = true;
         break;
@@ -141,7 +140,7 @@ public class AdiveryPlugin implements FlutterPlugin, MethodCallHandler, Activity
         requestRewardedAd((String) call.arguments);
         break;
       case "native":
-        requestNativeAd((String) call.argument("placement_id"), (String) call.argument("id"));
+        requestNativeAd(call.argument("placement_id"), call.argument("id"));
         break;
       case "isLoaded":
         result.success(Adivery.isLoaded((String) call.arguments));
@@ -187,9 +186,11 @@ public class AdiveryPlugin implements FlutterPlugin, MethodCallHandler, Activity
   }
 
   @Override
-  public void onDetachedFromEngine(FlutterPluginBinding binding) {
+  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
     Log.d("AdiveryPlugin", "detached from engine");
-    channel.setMethodCallHandler(null);
+    if (channel != null) {
+      channel.setMethodCallHandler(null);
+    }
     messenger = null;
     if (isInitialized) {
       Adivery.removeListener(listener);
@@ -207,7 +208,7 @@ public class AdiveryPlugin implements FlutterPlugin, MethodCallHandler, Activity
   }
 
   @Override
-  public void onReattachedToActivityForConfigChanges(ActivityPluginBinding binding) {
+  public void onReattachedToActivityForConfigChanges(@NonNull ActivityPluginBinding binding) {
 
   }
 


### PR DESCRIPTION
Firebase Messaging registers all native plugins in background isolate,
But Adivery should not register or initialize in background.
This is a workaround until a fix is provided by Firebase Messaging.